### PR TITLE
Bug found in auto_migrate

### DIFF
--- a/migrate-wordpress/control/modules/profile/manifests/wordpress/migrate.pp
+++ b/migrate-wordpress/control/modules/profile/manifests/wordpress/migrate.pp
@@ -68,6 +68,7 @@ class profile::wordpress::migrate(Boolean $auto_migrate = false) {
   if $auto_migrate {
     exec { 'automatic migration':
       command => '/root/migrate.sh',
+      path    => '/bin:/usr/bin',
       creates => '/root/migration_completed',
     }
   }

--- a/migrate-wordpress/control/modules/profile/templates/wordpress/migrate.sh.epp
+++ b/migrate-wordpress/control/modules/profile/templates/wordpress/migrate.sh.epp
@@ -14,7 +14,7 @@
 
 set -e
 
-mysqldump wordpress | mysql --host=<%= db_ip %> --password=<%= password %> -u wp-db wordpress
-rsync -avzPH -e "ssh -i /home/wp-user/.ssh/id_rsa" /opt/wordpress/wp-content/uploads wp-user@<%= $host_ip %>:/opt/wordpress/wp-content/
+mysqldump --defaults-extra-file=/root/.my.cnf wordpress | mysql --host=<%= $db_ip %> --password=<%= $password %> -u wp-db wordpress
+rsync -avzPH -e "ssh -i /home/wp-user/.ssh/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" /opt/wordpress/wp-content/ wp-user@<%= $host_ip %>:/opt/wordpress/wp-content/
 
 touch /root/migration_completed


### PR DESCRIPTION
  In live pre-demo testing it was found that Puppet does not load
  .my.cnf automatically because of the way it spawns a shell, fix was to
  just add the option explicitly to mysqldump.